### PR TITLE
chore: Remove restriction that signer/cork keys match

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- chore: Remove restriction that signer/cork keys match
+- chore: Remove `MismatchedKeyError`
+
 ## 0.2.1
 
 - chore: Move Cedar protobufs to the [cedar-dart](https://github.com/celest-dev/cedar-dart) repo

--- a/dart/lib/src/cork.dart
+++ b/dart/lib/src/cork.dart
@@ -147,10 +147,6 @@ final class Cork {
   }
 
   Future<Uint8List> _sign(Signer signer) async {
-    if (!signer.keyId.equals(id)) {
-      throw MismatchedKeyError(keyId: signer.keyId, corkId: id);
-    }
-
     signer.reset();
 
     var signature = await signer.sign(id);

--- a/dart/lib/src/exceptions.dart
+++ b/dart/lib/src/exceptions.dart
@@ -1,10 +1,6 @@
-import 'dart:typed_data';
-
-import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 
 import 'cork.dart';
-import 'signer.dart';
 
 /// {@template corks.invalid_cork_exception}
 /// Thrown when a [Cork] is invalid or corrupted and cannot be processed.
@@ -49,17 +45,4 @@ final class InvalidSignatureException implements Exception {
 final class MissingSignatureError extends StateError {
   /// {@macro corks.missing_signature_error}
   MissingSignatureError() : super('Cork has not been signed.');
-}
-
-/// {@template corks.mismatched_key_error}
-/// Thrown when a [Signer] key ID does not match the [Cork] ID.
-/// {@endtemplate}
-final class MismatchedKeyError extends ArgumentError {
-  /// {@macro corks.mismatched_key_error}
-  MismatchedKeyError({required Uint8List keyId, required Uint8List corkId})
-      : super(
-          'Signer key ID and cork ID do not match:\n'
-          'Key ID:  ${hex.encode(keyId)}\n'
-          'Cork ID: ${hex.encode(corkId)}',
-        );
 }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: corks_cedar
 description: An embedded authorization token format, based off Google's macaroons.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/celest-dev/corks/tree/main/dart
 
 environment:

--- a/dart/test/cedar_cork_test.dart
+++ b/dart/test/cedar_cork_test.dart
@@ -88,7 +88,6 @@ final _tests = <_TestCase>[
 
 final throwsInvalidCork = throwsA(isA<InvalidCorkException>());
 final throwsInvalidSignature = throwsA(isA<InvalidSignatureException>());
-final throwsMismatchedKey = throwsA(isA<MismatchedKeyError>());
 final throwsMissingSignature = throwsA(isA<MissingSignatureError>());
 
 void main() {
@@ -123,20 +122,10 @@ void main() {
               completes,
               reason: 'A signer should not depend on internal state',
             );
-
-            final invalidKeypairs = [
-              (bId, bKey, throwsMismatchedKey),
-              (aId, bKey, throwsInvalidSignature),
-              (bId, aKey, throwsMismatchedKey),
-            ];
-
-            for (final (id, key, throwsError) in invalidKeypairs) {
-              await expectLater(
-                () => signed.verify(Signer(id, key)),
-                throwsError,
-                reason: 'Mismatched key should fail verification',
-              );
-            }
+            await expectLater(
+              () => signed.verify(Signer(bId, bKey)),
+              throwsInvalidSignature,
+            );
           });
 
           test('encode/decode', () async {


### PR DESCRIPTION
This is too restrictive and can be managed in a more flexible way in application code.